### PR TITLE
[publish][m]: fix bitstore files wrong content-type

### DIFF
--- a/dpm/client/__init__.py
+++ b/dpm/client/__init__.py
@@ -183,8 +183,8 @@ class Client(object):
         md5 = md5_file_chunk(local_path)
         size = getsize(local_path)
 
-        file_type = 'binary/octet-stream'
-        if path.endswith('.json'):
+        file_type = 'text/plain'
+        if path.endswith('datapackage.json'):
             file_type = 'application/json'
 
         return {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -290,7 +290,7 @@ class ClientPublishSuccessTest(BaseClientTestCase):
                          "README.md": {
                              "md5": '2ODaQHCqodO2B/cbf03lgA==',
                              "size": 24,
-                             "type": 'binary/octet-stream',
+                             "type": 'text/plain',
                              'name': 'README.md'
                          },
                          "datapackage.json": {
@@ -302,7 +302,7 @@ class ClientPublishSuccessTest(BaseClientTestCase):
                          "data/some-data.csv": {
                              "md5": 'Nlu4VmSF8ZT6wK4QjL8iyw==',
                              "size": 12,
-                             "type": 'binary/octet-stream',
+                             "type": 'text/plain',
                              'name': 'data/some-data.csv'
                          }
                      }


### PR DESCRIPTION
Changes default file type to text/plain. Set file type application/json for datapackage.json
Changed related tests.

Fixes : https://github.com/frictionlessdata/dpr-api/issues/273